### PR TITLE
fix : load image_base_path in deck editor

### DIFF
--- a/scripts/card.gd
+++ b/scripts/card.gd
@@ -27,11 +27,15 @@ var mouse_is_in = false
 var shaking = false
 var shake_amount = 2
 var orginal_pos: Vector2
+
+# 해당 정보는 계승되어야 한다. (instance한 정보가 아님)
 var image_base_path = "./"
 
 
 func clone() -> Card:
 	var card = card_scene.instantiate()
+	# 자신의 base_path도 전달해준다 (중요한 정보임)
+	card.image_base_path = image_base_path
 	card.set_info(info)
 	card.global_position = global_position
 	return card

--- a/scripts/deck_editor.gd
+++ b/scripts/deck_editor.gd
@@ -12,6 +12,7 @@ func _ready():
 	
 	for cardInfo in cardInfos:
 		var card: Card = card_scene.instantiate()
+		card.image_base_path = card_json["imageBasePath"]
 		card.set_info(cardInfo)
 		card.show_card()
 		card.selectable = true


### PR DESCRIPTION
Deck Editor에서도 load 하도록 수정하였습니다. 

multiplayer_controller.gd의 select_hand_card에서도 load 하기에 조금 쌔했지만. 양쪽의 img_path가 같으면 문제가 없어보입니다. (아직 해당 코드에 이해가 부족하여 잘못생각하고 있을 수도 있습니다.) 로컬에서 멀티 플레이 테스트시에는 정상적으로 load 되었습니다. 